### PR TITLE
Simplify easeInQuint process

### DIFF
--- a/LTMorphingLabel/LTEasing.swift
+++ b/LTMorphingLabel/LTEasing.swift
@@ -23,9 +23,9 @@ public struct LTEasing {
     }
     
     public static func easeInQuint(_ t: Float, _ b: Float, _ c: Float, _ d: Float = 1.0) -> Float {
-        return {
-            return c * $0 * $0 * $0 * $0 * $0 + b
-            }(t / d)
+        let t1: Float = t / d
+        let t2: Float = c * t1 * t1 * t1 * t1 * t1 + b
+        return t2
     }
     
     public static func easeOutBack(_ t: Float, _ b: Float, _ c: Float, _ d: Float = 1.0) -> Float {


### PR DESCRIPTION
Xcode12 beta6にて下記のエラーによりコンパイルできず

`The compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions` 

![Screen Shot 2020-09-04 at 20 58 46](https://user-images.githubusercontent.com/2178775/92243932-31ed6700-eefd-11ea-898e-e3c3fb88df93.png)

この表現だと型チェックに時間がかかるとのことなのでシンプルな表現に修正した（書き方は変わっているが処理内容は同じ）。
なお、修正内容は本家で対応されていたものを適用した。
https://github.com/lexrus/LTMorphingLabel/blob/f85c731e87bc0f94a9ba3c86073091344e8fcbec/LTMorphingLabel/LTEasing.swift#L25